### PR TITLE
fix: setup mocking XHR request

### DIFF
--- a/src/app/components/header-overview/header-overview.component.ts
+++ b/src/app/components/header-overview/header-overview.component.ts
@@ -17,6 +17,6 @@ export class HeaderOverviewComponent implements OnInit {
   get headers(): [string, string][] {
     const headers = this.data ? this.data.mocks[this.data.activeStatusCode].headers : [];
 
-    return Object.entries(headers);
+    return Object.entries(headers || []);
   }
 }

--- a/src/injected/index.ts
+++ b/src/injected/index.ts
@@ -37,6 +37,9 @@ declare var window: any;
     try {
       log('Received state update', ev.data);
       mockXhr.state = ev.data;
+      mockXhr.onUpdate = json => {
+        window.postMessage(json, '*');
+      };
 
       if (!state || ev.data.enabled !== state.enabled) {
         mockXhr.disable();

--- a/src/injected/mock-fetch.ts
+++ b/src/injected/mock-fetch.ts
@@ -1,0 +1,5 @@
+import { IMockInject } from '../shared/type';
+
+export class MockFetch implements IMockInject {
+
+}

--- a/src/injected/mock-xhr-response.ts
+++ b/src/injected/mock-xhr-response.ts
@@ -1,0 +1,104 @@
+import { appSources, packetTypes, STORAGE_KEY } from '../shared/constants';
+import { IData, IMock, IMockInject, IPacket, requestType, statusCode } from '../shared/type';
+import { evalJsCode } from '../shared/utils/eval-jscode';
+import * as headers from '../shared/utils/xhr-headers';
+
+export class MockXhrResponse implements IMockInject {
+  private mock: IMock;
+  private response: unknown;
+  private responseTxt: string;
+
+  constructor(private xhr: XMLHttpRequest, private url, private type: requestType, private data: IData) {
+    this.mock = data?.mocks[data.activeStatusCode];
+  }
+
+  setResponse(response: string): void {
+    this.responseTxt = response;
+    this.response = JSON.parse(response);
+  }
+
+  willMock(): boolean {
+    return !!this.mock;
+  }
+
+  passThrough(): boolean {
+    return this.mock.passThrough;
+  }
+
+  changeUrl(url: string): string {
+    if (this.willMock()) {
+      const resp = {
+        [STORAGE_KEY]: {
+          sourceUrl: this.url,
+          mockUrl: this.data.url,
+          start: Date.now()
+        }
+      }
+      return 'data:application/json; charset=utf-8,' + encodeURIComponent(JSON.stringify(resp));
+    } else {
+      return url;
+    }
+  }
+
+  mockUpdateMessage(): IPacket | null {
+    if (!this.willMock() || this.passThrough()) {
+      return {
+        context: { url: this.url, method: 'XHR', type: this.type, statusCode: this.xhr.status },
+        domain: window.location.host,
+        source: appSources.INJECTED,
+        type: packetTypes.MOCK,
+        payload: { response: this.response, headers: headers.parse(this.xhr.getAllResponseHeaders()) }
+      };
+    }
+
+    return null;
+  }
+
+  mockResponse(): string {
+    if (!this.mock) {
+      return this.responseTxt;
+    }
+
+    try {
+      const code = evalJsCode(this.mock.jsCode);
+      return JSON.stringify(code(this.mock, this.response[STORAGE_KEY] ? null : this.response));
+    } catch (err) {
+      console.error('Could not execute jsCode', this.url, 'XHR', this.type, this.xhr.status, this.response, this.data);
+      return this.responseTxt;
+    }
+  }
+
+  mockStatusCode(): statusCode {
+    if (this.willMock()) {
+      return this.data.activeStatusCode;
+    }
+
+    return this.xhr.status;
+  }
+
+  mockXhrProperties(): void {
+    if (this.willMock) {
+      Object.defineProperty(this.xhr, 'status', { value: this.data.activeStatusCode });
+      Object.defineProperty(this.xhr, 'responseText', { value: this.responseTxt });
+      Object.defineProperty(this.xhr, 'response', { value: this.responseTxt });
+      Object.defineProperty(this.xhr, 'getAllResponseHeaders', { value: this.mockHeadersToString.bind(this) })
+      Object.defineProperty(this.xhr, 'getResponseHeader', { value: this.mockResponseHeader.bind(this) })
+    }
+  }
+
+  mockAllResponseHeaders(): Record<string, string> {
+    if (this.willMock()) {
+      return this.mock.headers || {};
+    } else {
+      return headers.parse(this.xhr.getAllResponseHeaders());
+    }
+  }
+
+  mockResponseHeader(key: string): string {
+    return (this.mock.headers || {})[key];
+  }
+
+  private mockHeadersToString(): string {
+    return headers.stringify(this.mock.headers)
+  }
+}

--- a/src/injected/mock-xhr.ts
+++ b/src/injected/mock-xhr.ts
@@ -1,0 +1,63 @@
+import { findActiveData } from '../shared/utils/find-mock';
+import { MockXhrResponse } from './mock-xhr-response';
+import * as headers from '../shared/utils/xhr-headers';
+
+export const mockXhr = {
+  memOpen: null,
+  state: null,
+  isMocking: function () { return !!this.memOpen },
+  enable: function () {
+    const self = this;
+    self.disable();
+
+    self.memOpen = XMLHttpRequest.prototype.open;
+    window.XMLHttpRequest.prototype.open = function (type, url, ...args) {
+      let _onreadystatechange = this.onreadystatechange;
+      const _this = this;
+      const mock = new MockXhrResponse(
+        this,
+        url,
+        type,
+        findActiveData(self.state, url, 'XHR', type));
+
+      url = mock.changeUrl(url);
+
+      _this.onreadystatechange = function () {
+        if (_this.readyState === 4) {
+          // TODO: response type is alwas JSON
+          mock.setResponse(_this.responseText);
+          const msg = mock.mockUpdateMessage();
+          // TODO: Post msg
+          const newRespStr = mock.mockResponse();
+
+          if (mock.willMock()) {
+            Object.defineProperty(_this, 'status', { value: mock.mockStatusCode() });
+            Object.defineProperty(_this, 'responseText', { value: newRespStr });
+            Object.defineProperty(_this, 'response', { value: newRespStr });
+            Object.defineProperty(_this, 'getAllResponseHeaders', { value: () => headers.stringify(mock.mockAllResponseHeaders()) })
+            Object.defineProperty(_this, 'getResponseHeader', { value: mock.mockResponseHeader.bind(mock) })
+          }
+        }
+        if (_onreadystatechange) _onreadystatechange.apply(this, arguments);
+      }
+
+      // detect any onreadystatechange changing
+      Object.defineProperty(this, "onreadystatechange", {
+        get: function () {
+          return _onreadystatechange;
+        },
+        set: function (value) {
+          _onreadystatechange = value;
+        }
+      });
+
+      return self.memOpen.call(_this, type, url, ...args);
+    }
+  },
+  disable: function () {
+    if (this.memOpen) {
+      window.XMLHttpRequest.prototype.open = this.memOpen;
+    }
+    this.memOpen = null;
+  }
+}

--- a/src/injected/mock-xml-http-request.ts
+++ b/src/injected/mock-xml-http-request.ts
@@ -37,7 +37,7 @@ export function setup(
           Object.defineProperty(_this, 'getAllResponseHeaders', { value: () => mockAllResponseHeadersFn(origHeaders, respJson)})
           Object.defineProperty(_this, 'getResponseHeader', { value: mockResponseHeader(_this, respJson)})
 
-          _this.getResponseHeader('date');
+          // _this.getResponseHeader('date');
           /////////////// END //////////////////
         } catch (e) { }
       }

--- a/src/injected/mocking.ts
+++ b/src/injected/mocking.ts
@@ -12,7 +12,7 @@ export const mockingFn = function (url: string, method: string, type: string): I
 
   return { [STORAGE_KEY]: {
       sourceUrl: url,
-      matchedUrl: data.url,
-      start: Date.now(),
-      mockIndex: this.state.data.indexOf(data) }};
+      mockUrl: data.url,
+      start: Date.now()}};
+      // mockIndex: this.state.data.indexOf(data) }};
 }

--- a/src/shared/type.ts
+++ b/src/shared/type.ts
@@ -82,10 +82,13 @@ export interface IPacket {
 export interface IMockedTmpResponse {
   [STORAGE_KEY]: {
     sourceUrl: string;
-    matchedUrl: string;
+    mockUrl: string;
     start: number;
-    mockIndex: number;
   }
 }
 
 export type ResetStateOptions = resetStateOptions;
+
+export interface IMockInject {
+
+}


### PR DESCRIPTION
The code to mock the XMLHttpRequest will be moved into a class. This to improve readability and to prepare for mocking FETCH requests