### PR TITLE
Feature/102 rename name to scenario

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,8 @@
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen",
 			"disableOptimisticBPs": true,
-			"protocol": "inspector"
+			"protocol": "inspector",
+     	"runtimeExecutable": "/usr/local/bin/node"
 		},
 		{
 			"type": "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-mock",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/components/content-type/content-type.component.ts
+++ b/src/app/components/content-type/content-type.component.ts
@@ -41,6 +41,6 @@ export class ContentTypeComponent implements OnInit {
   }
 
   ngOnChanges(): void {
-    [this.input, this.rest] = (this.contentType || '').match(/^([^;]+)(;?.*)$/).slice(1, 3);
+    [this.input, this.rest] = this.contentType?.match(/^([^;]+)(;?.*)$/)?.slice(1, 3) || [];
   }
 }

--- a/src/app/components/mock-label/mock-label.component.html
+++ b/src/app/components/mock-label/mock-label.component.html
@@ -1,1 +1,1 @@
-<span>{{code}}</span><span *ngIf="name"> - {{name}}</span>
+<span>{{code}}</span><span *ngIf="scenario"> - {{scenario}}</span>

--- a/src/app/components/mock-label/mock-label.component.ts
+++ b/src/app/components/mock-label/mock-label.component.ts
@@ -13,7 +13,7 @@ export class MockLabelComponent {
     return this.mock?.statusCode;
   }
 
-  get name(): string {
-    return this.mock?.name;
+  get scenario(): string {
+    return this.mock?.scenario;
   }
 }

--- a/src/app/components/mock/mock-details/mock-details.component.html
+++ b/src/app/components/mock/mock-details/mock-details.component.html
@@ -8,11 +8,11 @@
   </p>
   <p>
     <mat-form-field>
-      <mat-label>Name</mat-label>
-      <input matInput [formControl]="nameCtrl">
+      <mat-label>Scenario</mat-label>
+      <input matInput [formControl]="scenarioCtrl">
     </mat-form-field>
-    <mat-icon color="primary" matTooltip="Describes the mock's purpose in one or two words. This can be useful
-        if you have multple mocks with the same status code.">info
+    <mat-icon color="primary" matTooltip="With scenario's you can distinguish mocks with the same status code and mocks
+        can be activated by scenario (TODO).">info
     </mat-icon>
   </p>
   <p>

--- a/src/app/components/mock/mock-details/mock-details.component.ts
+++ b/src/app/components/mock/mock-details/mock-details.component.ts
@@ -43,11 +43,11 @@ export class MockDetailsComponent implements OnChanges {
       statusCode: new FormControl(this.mock.statusCode, {
         validators: [Validators.required], updateOn: 'blur'
       }),
-      name: new FormControl(this.mock.name, { updateOn: 'blur' })
+      scenario: new FormControl(this.mock.scenario, { updateOn: 'blur' })
     });
 
     this.form.valueChanges.subscribe(values => {
-      const update: Partial<IMock> = { name: values.name, delay: values.delay || 0 }
+      const update: Partial<IMock> = { scenario: values.scenario, delay: values.delay || 0 }
       if (!this.statusCodeCtrl.hasError('required')) {
         update.statusCode = values.statusCode;
       }
@@ -57,11 +57,13 @@ export class MockDetailsComponent implements OnChanges {
   }
 
   onContentTypeUpdate(contentType: string): void {
-    this.upsertMock({ headersMock: { ...this.mock.headersMock, 'content-type': contentType } });
+	  if (contentType !== this.mock.headersMock['content-type']) {
+    		this.upsertMock({ headersMock: { ...this.mock.headersMock, 'content-type': contentType } });
+	  }
   }
 
-  get nameCtrl(): FormControl {
-    return this.form.get('name') as FormControl;
+  get scenarioCtrl(): FormControl {
+    return this.form.get('scenario') as FormControl;
   }
 
   get statusCodeCtrl(): FormControl {

--- a/src/app/components/update-input/update-input.directive.ts
+++ b/src/app/components/update-input/update-input.directive.ts
@@ -34,7 +34,7 @@ export class UpdateInputDirective {
 
   ngOnChanges(): void {
     if (this.canUpdate()) {
-      (this.control as FormControlDirective).form.setValue(this.input);
+      setTimeout(() => (this.control as FormControlDirective).form.setValue(this.input));
     }
   }
 

--- a/src/app/migrations/current-domain.ts
+++ b/src/app/migrations/current-domain.ts
@@ -2,7 +2,7 @@ import { IOhMyMock } from '@shared/type'
 
 export const addCurrentDomain = (state: IOhMyMock, domain: string): IOhMyMock => {
   const domains = { ...state.domains }
-  domains[domain] ??= { domain, data: [], toggles: {}, views: {} };
+  domains[domain] ??= { domain, data: [], toggles: {}, views: {}, scenarios: {} };
 
   return { ...state, domains };
 }

--- a/src/app/migrations/index.ts
+++ b/src/app/migrations/index.ts
@@ -1,0 +1,12 @@
+import { migrate as v2121 } from './v2.12.1';
+import { IOhMyMock } from '@shared/type'
+
+import { IOhMygration } from './types';
+
+
+export const migrations: Record<string, IOhMygration> = {
+  '2.5.0': (state: IOhMyMock) => null, // reset
+  '2.12.1': v2121
+}
+
+export * from './types';

--- a/src/app/migrations/types.ts
+++ b/src/app/migrations/types.ts
@@ -1,0 +1,4 @@
+import { IOhMyMock } from '@shared/type';
+
+export type IOhMygration = (state: IOhMyMock) => IOhMyMock;
+export type IOhMygrations = Record<string, IOhMygration>;

--- a/src/app/migrations/v2.12.1.spec.ts
+++ b/src/app/migrations/v2.12.1.spec.ts
@@ -1,0 +1,24 @@
+import { IOhMyMock } from '@shared/type'
+import { testDataMock } from '@shared/test-site.mocks';
+import { migrate } from './v2.12.1';
+
+describe('Migrate to v2.12.1', () => {
+  let state: IOhMyMock;
+  beforeEach(() => {
+    const clone = JSON.parse(JSON.stringify(testDataMock));
+    const mock = clone.data[0].mocks[clone.data[0].activeMock];
+
+    (mock as any).name = 'old name';
+
+    state = { domains: { 'a': clone }, version: '1.1.1' };
+  });
+
+  it('should migrate name to scenario', () => {
+    const updated = migrate(state);
+    const data = updated.domains.a.data;
+    const mock = data[0].mocks[data[0].activeMock];
+
+    expect(mock.scenario).toBe('old name');
+    expect((mock as any).name).not.toBeDefined();
+  });
+});

--- a/src/app/migrations/v2.12.1.spec.ts
+++ b/src/app/migrations/v2.12.1.spec.ts
@@ -4,6 +4,7 @@ import { migrate } from './v2.12.1';
 
 describe('Migrate to v2.12.1', () => {
   let state: IOhMyMock;
+
   beforeEach(() => {
     const clone = JSON.parse(JSON.stringify(testDataMock));
     const mock = clone.data[0].mocks[clone.data[0].activeMock];
@@ -15,6 +16,7 @@ describe('Migrate to v2.12.1', () => {
 
   it('should migrate name to scenario', () => {
     const updated = migrate(state);
+
     const data = updated.domains.a.data;
     const mock = data[0].mocks[data[0].activeMock];
 

--- a/src/app/migrations/v2.12.1.ts
+++ b/src/app/migrations/v2.12.1.ts
@@ -1,9 +1,11 @@
-import { IOhMyMock, IData, IMock, ohMyDataId } from '@shared/type'
+import { IOhMyMock, IState, IData, IMock, ohMyDataId, ohMyScenarioId } from '@shared/type'
 
 export const migrate = (state: IOhMyMock): IOhMyMock => {
   const output = JSON.parse(JSON.stringify(state));
 
   Object.keys(state.domains).forEach(domain => {
+    output.domains[domain].scenarios = extractAllScenarios(state.domains[domain]);
+
     output.domains[domain].data.forEach((data: IData) => {
       Object.entries(data.mocks).forEach(([k, v]: [ohMyDataId, IMock]) => {
         data.mocks[k] = updateMock(v);
@@ -12,6 +14,22 @@ export const migrate = (state: IOhMyMock): IOhMyMock => {
   });
 
   return output;
+}
+
+function extractAllScenarios(state: IState): Record<ohMyScenarioId, string> {
+  const scenarios = {};
+
+  state.data.forEach(d => {
+    Object.values(d.mocks).forEach(mock => {
+      const name = (mock as any).name;
+
+      if (name) {
+        scenarios[name] = name;
+      }
+    });
+  });
+
+  return scenarios;
 }
 
 function updateMock(mock: IMock): IMock {

--- a/src/app/migrations/v2.12.1.ts
+++ b/src/app/migrations/v2.12.1.ts
@@ -1,0 +1,25 @@
+import { IOhMyMock, IData, IMock, ohMyDataId } from '@shared/type'
+
+export const migrate = (state: IOhMyMock): IOhMyMock => {
+  const output = JSON.parse(JSON.stringify(state));
+
+  Object.keys(state.domains).forEach(domain => {
+    output.domains[domain].data.forEach((data: IData) => {
+      Object.entries(data.mocks).forEach(([k, v]: [ohMyDataId, IMock]) => {
+        data.mocks[k] = updateMock(v);
+      });
+    });
+  });
+
+  return output;
+}
+
+function updateMock(mock: IMock): IMock {
+  const name = (mock as any).name;
+  const output = { ...mock };
+
+  output.scenario = name;
+  delete (output as any).name;
+
+  return output;
+}

--- a/src/app/services/migrations.service.spec.ts
+++ b/src/app/services/migrations.service.spec.ts
@@ -1,15 +1,16 @@
 import { MigrationsService } from './migrations.service';
+import { IOhMyMock } from '@shared/type';
 
 const CURRENT_VERSION = '200.6.0';
 
 describe('MigrationsService', () => {
   let service: MigrationsService;
-  let state: any;
+  let state: IOhMyMock;
 
   beforeEach(() => {
     state = {
       version: CURRENT_VERSION,
-      data: 'data'
+      domains: {}
     };
     service = new MigrationsService({ version: CURRENT_VERSION } as any)
   });

--- a/src/app/services/migrations.service.ts
+++ b/src/app/services/migrations.service.ts
@@ -32,7 +32,7 @@ export class MigrationsService {
   versions: string[];
 
   constructor(private appState: AppStateService) {
-    this.versions = Object.keys(migrations).sort();
+    this.versions = Object.keys(migrations).sort(compareVersions);
   }
 
   update(state: IOhMyMock = this.reset()): IOhMyMock {
@@ -44,7 +44,7 @@ export class MigrationsService {
       return state;
     }
 
-    if (version > this.appState.version) { // Can only happen with manual JSON imports
+    if (compareVersions(version, this.appState.version) === 1) { // Can only happen with manual JSON imports
       return this.reset();
     }
 

--- a/src/app/services/migrations.service.ts
+++ b/src/app/services/migrations.service.ts
@@ -4,6 +4,7 @@ import compareVersions from 'compare-versions';
 import { IOhMyMock } from '@shared/type';
 import { AppStateService } from './app-state.service';
 
+import { migrations, IOhMygrations } from '../migrations/'
 /**
  * Each new version might require the data of the previous version to be modified.
  * If this is the case, add that previous version in this list with a migration function.
@@ -18,9 +19,11 @@ import { AppStateService } from './app-state.service';
  * migrations obsolete. So, going from version 2.4.0 to the next cannot be migrated and
  * all data has to be removed.
  */
-export const MIGRATION_MAP = {
-  '2.5.0': (_) => null
-}
+
+// export const MIGRATION_MAP = {
+//   '2.5.0': (_) => null,
+//   '2.12.1': (_) => migrate
+// }
 
 @Injectable({
   providedIn: 'root'
@@ -29,7 +32,7 @@ export class MigrationsService {
   versions: string[];
 
   constructor(private appState: AppStateService) {
-    this.versions = Object.keys(MIGRATION_MAP).sort();
+    this.versions = Object.keys(migrations).sort();
   }
 
   update(state: IOhMyMock = this.reset()): IOhMyMock {
@@ -41,13 +44,13 @@ export class MigrationsService {
       return state;
     }
 
-    if (version > this.appState.version) { // Can only happen with imports
+    if (version > this.appState.version) { // Can only happen with manual JSON imports
       return this.reset();
     }
 
     for (let i = 0; i < this.versions.length; i++) {
       if (compareVersions(version, this.versions[i]) === -1) {
-        state = MIGRATION_MAP[this.versions[i]](state) || this.reset();
+        state = migrations[this.versions[i]](state) || this.reset();
         state.version = this.versions[i];
       }
     }
@@ -59,5 +62,9 @@ export class MigrationsService {
 
   reset(): IOhMyMock {
     return { domains: {}, version: this.appState.version };
+  }
+
+  getMigrations(): IOhMygrations {
+    return migrations;
   }
 }

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -22,7 +22,6 @@ export class StorageService {
     return new Promise((resolve) => {
       chrome.storage.local.get([STORAGE_KEY], (state: IStore) => {
         state[STORAGE_KEY] = this.migrateService.update(state[STORAGE_KEY]);
-
         resolve(state[STORAGE_KEY]);
       });
     });
@@ -35,7 +34,7 @@ export class StorageService {
   }
 
   update(update: IOhMyMock, key = STORAGE_KEY): void {
-    const updated = this.migrateService.update(update);
+    const updated = this.migrateService.update(update); // TODO: Is this needed?
     return chrome.storage.local.set({ [key]: updated });
   }
 

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -6,6 +6,7 @@ import {
   IOhMyToggle,
   ohMyMockId,
   ohMyDataId,
+  ohMyScenarioId,
 } from '@shared/type';
 
 export class InitState {
@@ -56,4 +57,9 @@ export class ViewReset {
 export class Toggle {
   static readonly type = '[Toggle] update';
   constructor(public payload: IOhMyToggle) { }
+}
+
+export class UpsertScenarios {
+  static readonly type = 'Scenario upsert';
+  constructor(public payload: Record<ohMyScenarioId, string>, public domain?: string) { }
 }

--- a/src/app/store/state.spec.ts
+++ b/src/app/store/state.spec.ts
@@ -80,6 +80,7 @@ describe('State', () => {
             data: [],
             domain: 'a',
             toggles: {},
+            scenarios: {},
             views: {
               hits: [],
               normal: [],

--- a/src/app/store/state.ts
+++ b/src/app/store/state.ts
@@ -15,6 +15,7 @@ import {
   Toggle,
   UpsertData,
   UpsertMock,
+  UpsertScenarios,
   ViewChangeOrderItems,
   ViewReset
 } from './actions';
@@ -30,6 +31,7 @@ import {
   ohMyMockId,
   ohMyDataId,
   IUpsertMock,
+  ohMyScenarioId,
 } from '@shared/type';
 import * as view from './views';
 import { MOCK_JS_CODE, STORAGE_KEY } from '@shared/constants';
@@ -70,7 +72,7 @@ export class OhMyState {
       output = (state as IOhMyMock).domains[domain];
     }
 
-    return output || { domain, views: {}, toggles: {}, data: [] };
+    return output || { domain, views: {}, toggles: {}, data: [], scenarios: {} };
   }
 
   static getMyState(ctx: StateContext<IOhMyMock>, domain: string): [IState, string] {
@@ -105,7 +107,7 @@ export class OhMyState {
 
     // TODO: unclear what `domain` argument is doing here, is it needed, don't think so?
     if (payload) {
-      domains[payload] = { domain: payload, data: [], toggles: {}, views: { normal: [], hits: [] } };
+      domains[payload] = { domain: payload, data: [], toggles: {}, views: { normal: [], hits: [] }, scenarios: {} };
       ctx.setState({ ...state, domains });
     } else {
       ctx.setState(addCurrentDomain(addTestData({ domains: {}, version: state.version }), OhMyState.domain));
@@ -173,6 +175,19 @@ export class OhMyState {
     }
 
     state.data = dataList;
+    const domains = { ...ctx.getState().domains };
+    domains[activeDomain] = state;
+
+    ctx.setState({ ...ctx.getState(), domains });
+  }
+
+  @Action(UpsertScenarios)
+  upsertScenarios(ctx: StateContext<IOhMyMock>, { payload, domain }: { payload: Record<ohMyScenarioId, string>, domain?: string }) {
+    const [state, activeDomain] = OhMyState.getMyState(ctx, domain);
+
+    // TODO: check for duplicate name values (replace old one???)
+    state.scenarios = { ...state.scenarios, ...payload };
+    
     const domains = { ...ctx.getState().domains };
     domains[activeDomain] = state;
 

--- a/src/app/store/state.upsert-data.spec.ts
+++ b/src/app/store/state.upsert-data.spec.ts
@@ -18,7 +18,7 @@ describe('Store#upsertData', () => {
     store = new OhMyState();
 
     state = {
-      domains: { 'localhost': { domain: 'test', data: [], views: { test: [1, 0, 2, 3] }, toggles: {} } }, version: '2.0.0'
+      domains: { 'localhost': { domain: 'test', scenarios: {}, data: [], views: { test: [1, 0, 2, 3] }, toggles: {} } }, version: '2.0.0'
     }
 
     ctx = {

--- a/src/app/store/state.upsert-mock.spec.ts
+++ b/src/app/store/state.upsert-mock.spec.ts
@@ -18,7 +18,7 @@ describe('Store#upsertMock', () => {
     store = new OhMyState();
 
     state = {
-      domains: { 'localhost': { domain: 'test', data: [], views: {}, toggles: {} } }, version: '2.0.0'
+      domains: { 'localhost': { domain: 'test', data: [], views: {}, toggles: {}, scenarios: {} } }, version: '2.0.0'
     }
 
     ctx = {

--- a/src/shared/test-site.mocks.ts
+++ b/src/shared/test-site.mocks.ts
@@ -48,7 +48,8 @@ export const testDataMock: IState = {
           "jsCode": "/* This is where OhMyMock creates responses.\nInside this sandbox you have access to the following data:\n  * `mock` - object with a cached response, header and status code\n  * request - details of the ongoing request\n  * fetch/XMLHttpRequest - the original objects\n    (Don't use window.fetch or window.XMLHttpRequest)\n\nIf your code is async, make sure to return a Promise which resolves a\nsimilar object as `mock`!! */\n\nreturn mock;\n",
           "response": "<html>\n<head><title>405 Not Allowed</title></head>\n<body bgcolor=\"white\">\n<center><h1>405 Not Allowed</h1></center>\n</body>\n</html>",
           "responseMock": "<html>\n<head><title>405 Not Allowed</title></head>\n<body bgcolor=\"white\">\n<center><h1>405 Not Allowed</h1></center>\n</body>\n</html>",
-          "statusCode": 409
+          "statusCode": 409,
+          "scenario": 'name'
         }
       },
       "type": "FETCH",

--- a/src/shared/test-site.mocks.ts
+++ b/src/shared/test-site.mocks.ts
@@ -2,6 +2,7 @@ import { DEMO_TEST_DOMAIN } from './constants';
 import { IState } from './type';
 
 export const testDataMock: IState = {
+  scenarios: { 'xyz': 'my scenario' },
   views: {
     "hits": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     "normal": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -49,7 +50,7 @@ export const testDataMock: IState = {
           "response": "<html>\n<head><title>405 Not Allowed</title></head>\n<body bgcolor=\"white\">\n<center><h1>405 Not Allowed</h1></center>\n</body>\n</html>",
           "responseMock": "<html>\n<head><title>405 Not Allowed</title></head>\n<body bgcolor=\"white\">\n<center><h1>405 Not Allowed</h1></center>\n</body>\n</html>",
           "statusCode": 409,
-          "scenario": 'name'
+          "scenario": 'xyz'
         }
       },
       "type": "FETCH",

--- a/src/shared/type.ts
+++ b/src/shared/type.ts
@@ -49,7 +49,7 @@ export interface IData extends IOhMyContext {
 
 export interface IMock {
   id: ohMyMockId;
-  name?: string;
+  scenario?: string;
   statusCode: statusCode;
   response?: string;
   type?: string;    // In application/json the `type` will be `application`

--- a/src/shared/type.ts
+++ b/src/shared/type.ts
@@ -15,6 +15,7 @@ export type origin = 'local' | 'cloud' | 'ngapimock';
 export type mockRuleType = keyof typeof MOCK_RULE_TYPES;
 export type ohMyDataId = string;
 export type ohMyMockId = string;
+export type ohMyScenarioId = string;
 
 export interface IStore {
   [STORAGE_KEY]: IOhMyMock;
@@ -30,6 +31,7 @@ export interface IState {
   data: IData[];
   views: Record<string, number[]>; // Projections
   toggles: Record<string, boolean>; // enable toggle and toggles for projections
+  scenarios: Record<ohMyScenarioId, string>
 }
 
 // url, method and type are used to map an API request with a mock


### PR DESCRIPTION
Scenarios are needed not only for NgApiMock but it is also convenient to be able to turn a specific scenario on with just one click. This PR prepares for all that. For now, this PR just renames the mock's `name` field to `scenario` AND creates a list per domain with all scenarios.